### PR TITLE
Add portfolio endpoints to API

### DIFF
--- a/backend/api_fast.py
+++ b/backend/api_fast.py
@@ -15,6 +15,7 @@ Dependencies (already in requirements.txt):
 from typing import List, Dict
 
 from fastapi import FastAPI, HTTPException, Query
+
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.fetch_truths_api import fetch_truths       # <- your helper function
@@ -84,5 +85,37 @@ def get_portfolio_data():
     """
     try:
         return portfolio_app.get_portfolio_data()
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=str(err))
+
+@app.get("/portfolio/graph", response_model=Dict)
+def get_graph_data(stock: str):
+    """
+    GET /portfolio/graph?stock={stock}  → returns graph data for a specific stock
+    """
+    try:
+        return portfolio_app.get_graph_data(stock)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=str(err))
+
+@app.post("/portfolio/add", response_model=Dict)
+def add_stock(stock: str):
+    """
+    POST /portfolio/add  → adds a stock to the portfolio
+    """
+    try:
+        portfolio_app.add_stock(stock)
+        return {"message": f"Stock {stock} added to portfolio"}
+    except Exception as err:
+        raise HTTPException(status_code=500, detail=str(err))
+
+@app.post("/portfolio/remove", response_model=Dict)
+def remove_stock(stock: str):
+    """
+    POST /portfolio/remove  → removes a stock from the portfolio
+    """
+    try:
+        portfolio_app.remove_stock(stock)
+        return {"message": f"Stock {stock} removed from portfolio"}
     except Exception as err:
         raise HTTPException(status_code=500, detail=str(err))

--- a/portfolio.py
+++ b/portfolio.py
@@ -298,6 +298,30 @@ class PortfolioApp(tk.Tk):
         }
         return portfolio_data
 
+    def get_graph_data(self, stock: str):
+        """Fetch graph data for a specific stock."""
+        period, interval = TIMEFRAMES[self.selected_tf]
+        data = yf.download(stock, period=period, interval=interval, progress=False, threads=False)
+        if data.empty:
+            raise ValueError("No data returned")
+        return data["Close"].to_json()
+
+    def add_stock(self, stock: str):
+        """Add a stock to the portfolio."""
+        if stock in self.portfolio:
+            raise ValueError(f"{stock} already in portfolio.")
+        try:
+            yf.Ticker(stock).fast_info  # simple validity check
+        except Exception:
+            raise ValueError(f"Ticker '{stock}' not found.")
+        self.portfolio.append(stock)
+
+    def remove_stock(self, stock: str):
+        """Remove a stock from the portfolio."""
+        if stock not in self.portfolio:
+            raise ValueError(f"{stock} not in portfolio.")
+        self.portfolio.remove(stock)
+
 
 if __name__ == "__main__":
     PortfolioApp().mainloop()


### PR DESCRIPTION
Add new endpoints to `backend/api_fast.py` and methods to `portfolio.py` to manage portfolio stocks and fetch graph data.

* **New Endpoints in `backend/api_fast.py`:**
  - Add `/portfolio/graph` endpoint to fetch graph data for a specific stock.
  - Add `/portfolio/add` endpoint to add a stock to the portfolio.
  - Add `/portfolio/remove` endpoint to remove a stock from the portfolio.

* **New Methods in `portfolio.py`:**
  - Add `get_graph_data` method to fetch graph data for a specific stock.
  - Add `add_stock` method to add a stock to the portfolio.
  - Add `remove_stock` method to remove a stock from the portfolio.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/brady29/DefinitelyNotFinancialAdvice/pull/2?shareId=6252229c-1050-4a2d-a7e0-cedb5ae22eaf).